### PR TITLE
Add example of usage for reinterpret_cast

### DIFF
--- a/docs/ch03-05-vectors.md
+++ b/docs/ch03-05-vectors.md
@@ -50,6 +50,18 @@ x.pop_back();
 auto size2 = x.size();  // 4
 ```
 
+## 配列の先頭ポインタを取得
+
+`x.data()` とすると配列の先頭ポインタが取得できます。
+
+```cpp
+#include <vector>
+
+std::vector<int> x = {4, 3, 2, 1, 0};
+auto px = x.data();  // 先頭ポインタ
+auto num = *px;  // 4
+```
+
 ## bool に対する特殊化
 
 `std::vector` は `bool` に対してテンプレート特殊化されており、

--- a/docs/ch08-01-cpp-casts.md
+++ b/docs/ch08-01-cpp-casts.md
@@ -53,3 +53,29 @@ B* b = reinterpret_cast<B*>(&a);
 
 変換後の型から変換前の型に戻すことができる点は保証されていますが、
 変換したものが正しく機能するかは実装に依存するため、なるべく `reinterpret_cast` を使わないようなコードを書くことが望ましいです。
+
+`reinterpret_cast` はバイナリデータの読み書き時に使われることがあります。
+入力ストリームの `read()` や出力ストリームの `write()` の第 1 引数のポインタの型が決まっているためです。
+
+```cpp hl_lines="17"
+#include <fstream>
+#include <vector>
+
+int main() {
+    std::vector<int> nums = {1, 2, 3, 4};
+
+    // バイナリ + 出力モードでストリームを開く
+    std::ofstream ofs("nums.bin", std::ios::binary | std::ios::out);
+    if(!ofs) {
+        return 1;
+    }
+
+    const auto size = sizeof(int) * nums.size();  // int のサイズ * 配列要素数
+
+    // 配列の先頭から配列全体のサイズ分をファイルに書き込む
+    // 先頭ポインタはキャストが必要
+    ofs.write(reinterpret_cast<const char *>(nums.data()), size);
+
+    return 0;
+}
+```


### PR DESCRIPTION
`std::vector` を例に出したかったので、合わせて `std::vector::data` の説明を追加

resolves #35 