### PR TITLE
fix(primitive-types): [u]intN_t type is defined in std namespace

### DIFF
--- a/docs/ch02-02-primitive-types.md
+++ b/docs/ch02-02-primitive-types.md
@@ -57,14 +57,14 @@ unsigned int x = 4000000000;
 移植性の面で問題が発生することがあります。
 そのようなときはサイズ指定付き整数型を使用します。
 
-* `int8_t`
-* `int16_t`
-* `int32_t`
-* `int64_t`
-* `uint8_t`
-* `uint16_t`
-* `uint32_t`
-* `uint64_t`
+* `std::int8_t`
+* `std::int16_t`
+* `std::int32_t`
+* `std::int64_t`
+* `std::uint8_t`
+* `std::uint16_t`
+* `std::uint32_t`
+* `std::uint64_t`
 
 数値は型のビットサイズを表しており、u は `unsigned` を表しています。
 サイズ指定付き整数型を使用する場合は `#include <cstdint>` と記述する必要があります。
@@ -72,7 +72,7 @@ unsigned int x = 4000000000;
 ```cpp
 #include <cstdint>
 
-int32_t x = 5;
+std::int32_t x = 5;
 ```
 
 ### 浮動小数点型


### PR DESCRIPTION
[u]intN_t型がグローバル名前空間にも宣言されている保証はないので、`std::`が必要です。

> https://timsong-cpp.github.io/cppwp/n4861/headers#5
> Except as noted in [library] through [thread] and [depr], the contents of each header cname is the same as that of the corresponding header name.h as specified in the C standard library.
**In the C++ standard library, however, the declarations (except for names which are defined as macros in C) are within namespace scope of the namespace std.**
It is unspecified whether these names (including any overloads added in [support] through [thread] and [depr]) are first declared within the global namespace scope and are then injected into namespace std by explicit using-declarations.