### PR TITLE
fix(maps): std::unorderd_map is aways better then std::map

### DIFF
--- a/docs/ch03-06-maps.md
+++ b/docs/ch03-06-maps.md
@@ -52,4 +52,4 @@ persons.erase("Bob");
 `std::map` はキーでソートしてデータを管理するのに対し、
 `std::unordered_map` はキーから計算するハッシュと呼ばれる値でデータを管理します。
 
-効率のよいハッシュ計算を行える場合には `std::unordered_map` の方が適しています。
+キーの順番を保持したい場合を除いて常に `std::unordered_map` の方が優れています。


### PR DESCRIPTION
キーの順番を保持したい場合を除いて、常にstd::unorderd_mapを利用するべきである。メモリー効率も実行速度も優れている。

ref:
- https://qiita.com/Nabetani/items/78281cc98547f8edfea4
- https://www.madopro.net/entry/2016/09/08/091348
- https://sleepy-yoshi.hatenablog.com/entry/20121111/p1